### PR TITLE
behavior testing, local & prod.

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,8 +4,10 @@
   "description": "Create a CSS color gradient to reflect two separate cultural ideas and emotions.",
   "main": "index.html",
   "scripts": {
-      "watch-css": "nodemon -e scss -x \"npm run build-css\"",
-      "build-css": "node-sass --include-path scss css/main.scss | cleancss -o css/main.min.css"
+    "watch-css": "nodemon -e scss -x \"npm run build-css\"",
+    "build-css": "node-sass --include-path scss css/main.scss | cleancss -o css/main.min.css",
+    "test": "node test.js | faucet",
+    "test-prod": "TESTING_URL=PRODUCTION node test.js | faucet"
   },
   "repository": {
     "type": "git",
@@ -16,5 +18,11 @@
   "bugs": {
     "url": "https://github.com/gcwelborn/Colors-in-Culture/issues"
   },
-  "homepage": "https://github.com/gcwelborn/Colors-in-Culture#readme"
+  "homepage": "https://github.com/gcwelborn/Colors-in-Culture#readme",
+  "dependencies": {
+    "express": "^4.13.4",
+    "faucet": "0.0.1",
+    "nightmare": "^2.5.1",
+    "tape": "^4.5.1"
+  }
 }

--- a/test.js
+++ b/test.js
@@ -1,0 +1,79 @@
+'use strict'
+const test = require('tape'); // TAP harness
+const Nightmare = require('nightmare'); // Browser Automator
+const nightmare_config = {show: true, gotoTimeout: 3000};
+
+// decide which URL to test for
+let TESTING_URL, localhost;
+if (process.env.TESTING_URL === 'PRODUCTION') {
+  TESTING_URL = 'http://culturecolors.xyz';
+} else {
+  TESTING_URL = 'http://localhost:3000';
+  localhost = require('express')();
+  localhost.use('/', require('express').static(__dirname));
+  localhost = localhost.listen('3000', () => console.log('listening on port 3000'));
+}
+
+// main function call
+main();
+
+// browser automation, interact-scrape-test
+function main() {
+    new Nightmare(nightmare_config)
+        .goto(TESTING_URL)
+        .evaluate(dispatch_actions_and_gather_pageInfo)
+        .end()
+        .then((page_info) => test_suite(page_info))
+        .catch((err) => console.log(err))
+}
+
+// dispatch actions/change state to new_test_State, then return redux state/bvg
+// *occurs in DOM for cultureColors.xyz outside of node.js scope
+function dispatch_actions_and_gather_pageInfo() {
+    let new_test_state = [store, 'Western', 'Cold', 'Anger'];
+
+    // dispatch a series of actions to change Culture and Values
+    (function changeStateTo(store, culture, first_value, second_value) {
+      store.dispatch({type:'CULTURE_CHANGE',culture:culture})
+      store.dispatch({type:'VALUE_CHANGE',side:'LEFT',value:first_value})
+      store.dispatch({type:'VALUE_CHANGE',side:'RIGHT',value:second_value})
+    })(...new_test_state)
+
+    let test_background = document.body.style.background;
+    let test_state = store.getState();
+
+    //  return Background, Redux state, and culture_data.js object lookup
+    return { test_background, test_state, cultures}
+}
+
+// receives page_info from nightmare.evaluate(),
+//   asserting it against expected results.
+function test_suite(page_info) {
+    let actual_background = page_info.test_background;
+    let actual_state = page_info.test_state;
+    let expected_background = "linear-gradient(to right, rgb(41, 128, 185), rgb(231, 76, 60))";
+    let expected_state = { culture: 'Western', first_value: 'Cold', 'second_value': 'Anger' };
+
+    test('background matches expected', T => {
+        T.plan(2);
+        T.notEqual(actual_background, null);
+        T.deepEqual(actual_background, expected_background);
+    });
+
+    test('state matches expected', T => {
+        T.plan(2);
+        T.notEqual(actual_state, null);
+        T.deepEqual(actual_state, expected_state);
+    });
+
+    test('Cultures are all present', T => {
+      let cultures = Object.keys(page_info.cultures);
+      T.plan(1);
+      T.equal(cultures.length, 10);
+    })
+
+    // if testing localhost, shutdown server after testing
+    test.onFinish(() => {
+      if (localhost) localhost.close();
+    })
+}


### PR DESCRIPTION
- added two NPM scripts, one to run tests again local version and one
  for production (@culturecolors.xyz)
- used nightmare to dispatch actions, and return the redux state and
  document body’s background-gradient.
- used Tape to assert expected vs. actual results for
  Wester:Cold-Anger, on both the state and bicolor.
- assert there are ten cultures on the page.
